### PR TITLE
fix(proto,go): remove go_package options, use buf managed mode.

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,3 @@
+version: "v2"
+managed:
+  enabled: true

--- a/buf.yaml
+++ b/buf.yaml
@@ -16,6 +16,7 @@ modules:
       except:
         - EXTENSION_NO_DELETE
         - FIELD_SAME_DEFAULT
+        - FILE_SAME_GO_PACKAGE
   - path: proto/aep-conformance
     name: buf.build/aep/conformance
     lint:
@@ -34,6 +35,7 @@ modules:
       except:
         - EXTENSION_NO_DELETE
         - FIELD_SAME_DEFAULT
+        - FILE_SAME_GO_PACKAGE
   - path: proto/aep-type
     name: buf.build/aep/type
     lint:
@@ -50,6 +52,7 @@ modules:
       except:
         - EXTENSION_NO_DELETE
         - FIELD_SAME_DEFAULT
+        - FILE_SAME_GO_PACKAGE
 deps:
   - buf.build/bufbuild/protovalidate
   - buf.build/googleapis/googleapis

--- a/proto/aep-api/aep/api/field_info.proto
+++ b/proto/aep-api/aep/api/field_info.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package aep.api;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/api";
 option java_multiple_files = true;
 option java_outer_classname = "FieldBehaviorProto";
 option java_package = "dev.aep.api";

--- a/proto/aep-api/aep/api/idempotency_key.proto
+++ b/proto/aep-api/aep/api/idempotency_key.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package aep.api;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/api";
 option java_multiple_files = true;
 option java_outer_classname = "IdempotencyKeyProto";
 option java_package = "dev.aep.api";

--- a/proto/aep-api/aep/api/operation.proto
+++ b/proto/aep-api/aep/api/operation.proto
@@ -22,7 +22,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/descriptor.proto";
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/api";
 option java_multiple_files = true;
 option java_outer_classname = "OperationsProto";
 option java_package = "dev.aep.api";
@@ -34,7 +33,7 @@ extend google.protobuf.MethodOptions {
   // long-running operations.
   //
   // Required for methods that return `aep.api.Operation`; invalid otherwise.
-  aep.api.OperationInfo operation_info = 1049;
+  aep.api.OperationInfo operation_info = 1264;
 }
 
 // This resource represents a long-running operation that is the result of a

--- a/proto/aep-api/aep/api/problem_details.proto
+++ b/proto/aep-api/aep/api/problem_details.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package aep.api;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/api";
 option java_multiple_files = true;
 option java_outer_classname = "ProblemDetailsProto";
 option java_package = "dev.aep.api";

--- a/proto/aep-conformance/aep/conformance/proto2/test_all_types.proto
+++ b/proto/aep-conformance/aep/conformance/proto2/test_all_types.proto
@@ -9,7 +9,6 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/conformance/proto2";
 option java_multiple_files = true;
 option java_outer_classname = "TestAllTypesProto";
 option java_package = "dev.aep.conformance.proto2";

--- a/proto/aep-conformance/aep/conformance/proto3/test_all_types.proto
+++ b/proto/aep-conformance/aep/conformance/proto3/test_all_types.proto
@@ -9,7 +9,6 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/conformance/proto3";
 option java_multiple_files = true;
 option java_outer_classname = "TestAllTypesProto";
 option java_package = "dev.aep.conformance.proto3";

--- a/proto/aep-type/aep/type/decimal.proto
+++ b/proto/aep-type/aep/type/decimal.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package aep.type;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/type";
 option java_multiple_files = true;
 option java_outer_classname = "DecimalProto";
 option java_package = "dev.aep.type";

--- a/proto/aep-type/aep/type/interval.proto
+++ b/proto/aep-type/aep/type/interval.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 package aep.type;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/type";
 option java_multiple_files = true;
 option java_outer_classname = "PhoneNumberProto";
 option java_package = "dev.aep.type";

--- a/proto/aep-type/aep/type/money.proto
+++ b/proto/aep-type/aep/type/money.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package aep.type;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/type";
 option java_multiple_files = true;
 option java_outer_classname = "MoneyProto";
 option java_package = "dev.aep.type";

--- a/proto/aep-type/aep/type/phone_number.proto
+++ b/proto/aep-type/aep/type/phone_number.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 package aep.type;
 
 option cc_enable_arenas = true;
-option go_package = "aep.dev/type";
 option java_multiple_files = true;
 option java_outer_classname = "PhoneNumberProto";
 option java_package = "dev.aep.type";


### PR DESCRIPTION
Today, we specify "aep.dev/api" as the go package
to build. When used in conjunction with buf's generated go  SDK, the following occurs:

```
go mod tidy
go: finding module for package aep.dev/api
go: github.com/aep-dev/aepc/example/bookstore/v1 imports
        aep.dev/api: cannot find module providing package aep.dev/api: unrecognized import path "aep.dev/api": reading https://aep.dev/api?go-get=1: 404 Not Found
11:5
```

This is because we do not actually have our generated go code. In addition, this patterns forces consumers to consume these generated SDKs at that package path, making it impossible for the consumer to control the generated package directory.

Instead, we can use buf managed mode so that the
packages match automatically: https://buf.build/docs/generate/managed-mode/#enable-managed-mode. hosted at aep.dev/api. 