### PR TITLE
feat(proto,operation): add operations service

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -9,6 +9,10 @@ modules:
         - FIELD_NOT_REQUIRED
         - PACKAGE_NO_IMPORT_CYCLE
         - PACKAGE_VERSION_SUFFIX
+        # skip Operation, Empty as responses
+        - RPC_RESPONSE_STANDARD_NAME
+        - RPC_REQUEST_STANDARD_NAME
+        - RPC_REQUEST_RESPONSE_UNIQUE
       disallow_comment_ignores: true
     breaking:
       use:

--- a/proto/aep-api/aep/api/operation.proto
+++ b/proto/aep-api/aep/api/operation.proto
@@ -17,7 +17,10 @@ syntax = "proto3";
 package aep.api;
 
 import "aep/api/problem_details.proto";
+import "google/api/annotations.proto";
+import "google/api/client.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/descriptor.proto";
 
@@ -34,7 +37,80 @@ extend google.protobuf.MethodOptions {
   // long-running operations.
   //
   // Required for methods that return `aep.api.Operation`; invalid otherwise.
-  aep.api.OperationInfo operation_info = 1049;
+  // see https://github.com/protocolbuffers/protobuf/pull/20839
+  aep.api.OperationInfo operation_info = 1264;
+}
+
+// Manages long-running operations with an API service.
+//
+// When an API method normally takes long time to complete, it can be designed
+// to return [Operation][aep.api.Operation] to the client, and the
+// client can use this interface to receive the real response asynchronously by
+// polling the operation resource, or pass the operation resource to another API
+// (such as Pub/Sub API) to receive the response.  Any API service that returns
+// long-running operations should implement the `Operations` interface so
+// developers can have a consistent client experience.
+service OperationsService {
+
+  // Lists operations that match the specified filter in the request. If the
+  // server doesn't support this method, it returns `UNIMPLEMENTED`.
+  rpc ListOperations(ListOperationsRequest) returns (ListOperationsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{name=operations}"
+    };
+    option (google.api.method_signature) = "name,filter";
+  }
+
+  // Gets the latest state of a long-running operation.  Clients can use this
+  // method to poll the operation result at intervals as recommended by the API
+  // service.
+  rpc GetOperation(GetOperationRequest) returns (Operation) {
+    option (google.api.http) = {
+      get: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Deletes a long-running operation. This method indicates that the client is
+  // no longer interested in the operation result. It does not cancel the
+  // operation. If the server doesn't support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  rpc DeleteOperation(DeleteOperationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Starts asynchronous cancellation on a long-running operation.  The server
+  // makes a best effort to cancel the operation, but success is not
+  // guaranteed.  If the server doesn't support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+  // [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+  // other methods to check whether the cancellation succeeded or whether the
+  // operation completed despite cancellation. On successful cancellation,
+  // the operation is not deleted; instead, it becomes an operation with
+  // an [Operation.error][google.longrunning.Operation.error] value with a
+  // [google.rpc.Status.code][google.rpc.Status.code] of `1`, corresponding to
+  // `Code.CANCELLED`.
+  rpc CancelOperation(CancelOperationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1/{name=operations/**}:cancel"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Waits until the specified long-running operation is done or reaches at most
+  // a specified timeout, returning the latest state.  If the operation is
+  // already done, the latest state is immediately returned.  If the timeout
+  // specified is greater than the default HTTP/RPC timeout, the HTTP/RPC
+  // timeout is used.  If the server does not support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  // Note that this method is on a best-effort basis.  It may return the latest
+  // state before the specified timeout (including immediately), meaning even an
+  // immediate response is no guarantee that the operation is done.
+  rpc WaitOperation(WaitOperationRequest) returns (Operation) {}
 }
 
 // This resource represents a long-running operation that is the result of a


### PR DESCRIPTION
Operations service was not added in a previous commit. Having the service makes it easier to implement against  the spec in consumers (like aepc).