### PR TITLE
fix(json-schema/type): rename to types

### DIFF
--- a/json_schema/types/decimal.yaml
+++ b/json_schema/types/decimal.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://aep.dev/json-schema/type/decimal.json
+$id: https://aep.dev/json-schema/types/decimal.json
 title: Decimal
 description: |
   Represents a decimal number in a form similar to scientific notation.

--- a/json_schema/types/interval.yaml
+++ b/json_schema/types/interval.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://aep.dev/json-schema/type/interval.json
+$id: https://aep.dev/json-schema/types/interval.json
 title: Interval
 description: |
   Represents a time interval, encoded as a Timestamp start (inclusive) and a

--- a/json_schema/types/money.yaml
+++ b/json_schema/types/money.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://aep.dev/json-schema/type/money.json
+$id: https://aep.dev/json-schema/types/money.json
 title: Money
 description: |
   Represents an amount of money with its currency type.

--- a/json_schema/types/operation.yaml
+++ b/json_schema/types/operation.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://aep.dev/json-schema/type/operation.json
+$id: https://aep.dev/json-schema/types/operation.json
 type: object
 description: "Represents a Long Running Operation that can be used to check the status of an asynchronous operation."
 required:

--- a/json_schema/types/problems.yaml
+++ b/json_schema/types/problems.yaml
@@ -1,5 +1,5 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://aep.dev/json-schema/type/problems.json
+$id: https://aep.dev/json-schema/types/problems.json
 title: An RFC 7807 problem object
 type: object
 properties:


### PR DESCRIPTION
The AEPs propose a pattern where resources are located at collections using the resource plural. Although not strictly required,  it's inconsistent for our json schemas not to follow this practice.