### PR TITLE
feat(151, oas): add an openapi extension for x-aep-long-running-operation

### DIFF
--- a/json_schema/extensions/x-aep-long-running-operation.yaml
+++ b/json_schema/extensions/x-aep-long-running-operation.yaml
@@ -1,0 +1,45 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://aep.dev/json-schema/extensions/x-aep-long-running-operation.json
+type: object
+description: |
+  Represents metadata about a long-running operation. The
+  extensions is used to provide additional information about
+  an OpenAPI Operation object.
+
+  Should be used in APIs where the response type is
+  https://aep.dev/json-schema/type/operation.json, to
+  provide additional information that is required for
+  aep clients to interface with the operation.
+
+  Example:
+
+  ```yaml
+  paths:
+    "/v1/books/{book_id}:archiveBook":
+      post:
+        operationId: archiveBook
+        description: Archive a book, not allowing further editing.
+        x-aep-long-running-operation:
+          response:
+            schema:
+              $ref: https://aep.dev/json-schema/type/operation.json
+        responses:
+          200:
+            ...
+  ```
+required:
+  - response
+additionalProperties: false
+properties:
+  response:
+    description: Information about the response of the operation.
+    type: object
+    properties:
+      schema:
+        description: |
+          The schema of the response of the operation.
+
+          This is a Schema that describes the structure of the response
+          object of the completed long-running-operation. It must be a valid
+          OpenAPI Schema (preferably a JSON Schema).
+        type: object

--- a/json_schema/extensions/x-aep-long-running-operation.yaml
+++ b/json_schema/extensions/x-aep-long-running-operation.yaml
@@ -20,26 +20,32 @@ description: |
         operationId: archiveBook
         description: Archive a book, not allowing further editing.
         x-aep-long-running-operation:
-          response:
-            schema:
+          response_type:
               $ref: https://aep.dev/json-schema/type/operation.json
+          metadata_type:
+              type: object
+              properties:
+                progress:
+                  type: number
+                  minimum: 0
+                  maximum: 100
         responses:
           200:
             ...
   ```
 required:
-  - response
+  - response_type
 additionalProperties: false
 properties:
-  response:
-    description: Information about the response of the operation.
+  response_type:
     type: object
-    properties:
-      schema:
-        description: |
-          The schema of the response of the operation.
-
-          This is a Schema that describes the structure of the response
-          object of the completed long-running-operation. It must be a valid
-          OpenAPI Schema (preferably a JSON Schema).
-        type: object
+    description: |
+      A schema that describes the structure of the response
+      object of the completed long-running-operation. It must be a valid
+      OpenAPI Schema (preferably a JSON Schema).
+  metadata_type:
+    type: object
+    description: |
+      A schema that describes the structure of the metadata
+      object of the long-running-operation. It must be a valid
+      OpenAPI Schema (preferably a JSON Schema).


### PR DESCRIPTION
Clients will have to do significant inference around things like response types without additional documentation the client.

This change adds the minimally required information, but is designed to allow additional properties (perhaps things like timeouts) in the schema.