### PR TITLE
fix(operation, oas): fix required field for path

### DIFF
--- a/.github/workflows/build-and-publish-protos.yaml
+++ b/.github/workflows/build-and-publish-protos.yaml
@@ -4,13 +4,13 @@ on:
   push:
     paths:
       - .github/workflows/build-and-publish-protos.yaml
-      - 'proto/**'
+      - "proto/**"
       - buf.yaml
       - buf.lock
   pull_request:
     paths:
       - .github/workflows/build-and-publish-protos.yaml
-      - 'proto/**'
+      - "proto/**"
       - buf.yaml
       - buf.lock
     types: [opened, synchronize, reopened, labeled, unlabeled]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install prettier.
-        run: npm install --global prettier
+        run: npm install --global prettier@3.6.2
       - name: Verify proper formatting.
         run: prettier --check **/*.md

--- a/json_schema/type/operation.yaml
+++ b/json_schema/type/operation.yaml
@@ -3,7 +3,7 @@ $id: https://aep.dev/json-schema/type/operation.json
 type: object
 description: "Represents a Long Running Operation that can be used to check the status of an asynchronous operation."
 required:
-  - name
+  - path
   - done
 properties:
   path:

--- a/schemas/type/money.md
+++ b/schemas/type/money.md
@@ -16,7 +16,6 @@ A `Money` has two fields:
   with "X-", in order to distinguish them from potential future ISO 4217 codes.
 
   Examples:
-
   - "USD" - ISO 4217 code for United States dollar
   - "X-BTC" - Potential API-defined extension for Bitcoin.
   - "X-.RBX" - Potential API-defined extension for the virtual currency Robux

--- a/schemas/type/operation.md
+++ b/schemas/type/operation.md
@@ -22,7 +22,6 @@ An `Operation` has the following fields:
   populated.
 
 - Two mutually exclusive fields containing the result of an operation:
-
   - `error` is the error result of the operation in case of failure or
     cancellation. Its type should match the standard error representation in a
     given API or IDL (for example, `aep.api.ProblemDetails` in protocol buffer

--- a/schemas/type/phone_number.md
+++ b/schemas/type/phone_number.md
@@ -42,7 +42,6 @@ A `PhoneNumber` has two main fields, exactly one of which must be populated:
   number that uses a relaxed ITU E.164 format consisting of the country calling
   code (1 to 3 digits) and the subscriber number, with no additional spaces or
   formatting, e.g.:
-
   - correct: "+15552220123"
   - incorrect: "+1 (555) 222-01234 x123".
 


### PR DESCRIPTION
the `name` field does not exist in the schema: this is a legacy artifact from adapting aip.dev

fixes https://github.com/aep-dev/aeps/issues/312