### PR TITLE
feat(x-aep-resource): add type annotation

### DIFF
--- a/json_schema/extensions/x-aep-resource.yaml
+++ b/json_schema/extensions/x-aep-resource.yaml
@@ -27,3 +27,8 @@ properties:
     type: boolean
     description: If true, the resource is a singleton.
     default: false
+  type:
+    type: string
+    description: >
+      The type of resource, in the form of `{api name}.{resource singular}`.
+      For example, `api.examples.com/user`.


### PR DESCRIPTION
To match the proto definition and enable clarify in the resource, adding the type string. This also helps flesh out some guidance in https://github.com/aep-dev/aeps/pull/354