### PR TITLE
feat(field): add resource reference syntax

### DIFF
--- a/json_schema/extensions/x-aep-field.yaml
+++ b/json_schema/extensions/x-aep-field.yaml
@@ -17,3 +17,19 @@ properties:
         # This indicates that the field is provided in requests, and the
         # corresponding field is not included in output.
         - "INPUT_ONLY"
+  resource_reference:
+    description: Describes a resource reference for fields that reference API resources
+    type: object
+    properties:
+      type:
+        description: |
+          The resource type that the annotated field references.
+
+          Example:
+            "library.example.com/Topic"
+
+          Occasionally, a field may reference an arbitrary resource. In this case,
+          APIs use the special value "*" in their resource reference.
+        type: array
+        items: string
+    additionalProperties: false

--- a/proto/aep-api/aep/api/field_info.proto
+++ b/proto/aep-api/aep/api/field_info.proto
@@ -17,6 +17,38 @@ extend google.protobuf.FieldOptions {
   FieldInfo field_info = 10520;
 }
 
+// Defines a proto annotation that describes a string field that refers to
+// an API resource.
+message ResourceReference {
+  // The resource type that the annotated field references.
+  //
+  // Example:
+  //
+  //     message Subscription {
+  //       string topic = 2 [(aep.api.field_info) = {
+  //         resource_reference: {
+  //           type: "library.example.com/Topic"
+  //           // multiple types are allowed.
+  //           type: "library.example.com/OtherTopic"
+  //         }
+  //       }];
+  //     }
+  //
+  // Occasionally, a field may reference an arbitrary resource. In this case,
+  // APIs use the special value * in their resource reference.
+  //
+  // Example:
+  //
+  //     message GetResourceRequest {
+  //       string resource = 2 [(aep.api.field_info) = {
+  //         resource_reference: {
+  //           type: "*"
+  //         }
+  //       }];
+  //     }
+  repeated string type = 1;
+}
+
 // Various options related to the behavior of a field.
 //
 // This is, conceptually, supplementary to `google.api.FieldInfo`.
@@ -32,4 +64,7 @@ message FieldInfo {
   // the minimum lifetime is a strict cutoff. For example, an API may honor an
   // idempotency key indefinitely, whatever the value of this field option.
   google.protobuf.Duration minimum_lifetime = 1;
+
+  // An annotation that describes a resource reference.
+  ResourceReference resource_reference = 2;
 }


### PR DESCRIPTION
AEPs do not currently have a first-class annotation for resource references. 

It would be good to have one long-term, as it helps if it  is necessary to extent it beyond existing proto annotations. In  addition, there is no such concept in oas.

At minimum, the new syntax allows for repeated resource reference types, which will enable patterns where a single field can be populated with more than one type.