### PR TITLE
Add resource_reference_child_type

### DIFF
--- a/proto/aep-api/aep/api/field_info.proto
+++ b/proto/aep-api/aep/api/field_info.proto
@@ -58,6 +58,9 @@ message FieldInfo {
   //     }
   repeated string resource_reference = 2;
 
+  // The resource type that the child collection annotates.
+  repeated string resource_reference_child_type = 4;
+
   // Describes the behavior of the field in requests and responses.
   repeated FieldBehavior field_behavior = 3;
 }


### PR DESCRIPTION
Relates to https://github.com/aep-dev/api-linter/issues/112

This adds `resource_reference_child_type`. This needs to be merged before we can fix the linter rules.