### PR TITLE
feat(x-aep-field, oas): add resource reference child type

### DIFF
--- a/json_schema/extensions/x-aep-field.yaml
+++ b/json_schema/extensions/x-aep-field.yaml
@@ -18,18 +18,22 @@ properties:
         # corresponding field is not included in output.
         - "INPUT_ONLY"
   resource_reference:
-    description: Describes a resource reference for fields that reference API resources
-    type: object
-    properties:
-      type:
-        description: |
-          The resource type that the annotated field references.
+    description: |
+      The resource type that the annotated field references.
 
-          Example:
-            "library.example.com/Topic"
+      Example:
+        "library.example.com/topic"
 
-          Occasionally, a field may reference an arbitrary resource. In this case,
-          APIs use the special value "*" in their resource reference.
-        type: array
-        items: string
-    additionalProperties: false
+      Occasionally, a field may reference an arbitrary resource. In this case,
+      APIs use the special value "*" in their resource reference.
+    type: array
+    items: string
+  resource_reference_child_type:
+    description: |
+      The field annotated with this supports all resources that have
+      child types of the resource specified.
+
+      Example:
+        "library.example.com/topic"
+    type: array
+    items: string


### PR DESCRIPTION
matching the proto annotations (also removing the nested field to match).