### PR TITLE
feat(x-aep-field): add field number

### DIFF
--- a/json_schema/extensions/x-aep-field.yaml
+++ b/json_schema/extensions/x-aep-field.yaml
@@ -37,3 +37,9 @@ properties:
         "library.example.com/topic"
     type: array
     items: string
+  field_number:
+    description: |
+      A unique identifier for the field. This is useful when doing translation
+      to protocols that require indexing of fields, such as Protocol Buffers.
+    type: integer
+    minimum: 1


### PR DESCRIPTION
field numbers are not officially required by the AEPs, but are useful for enumeration in intermediary representations such as resource definitions for aep-lib-go.